### PR TITLE
Allow PDB files with missing CRYST1 records to be loaded

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ license = {file = "LICENSE"}
 keywords = ["pdb-files"]
 authors = [
   {name = "Patrick Kunzmann"},
+  {name = "Nick Coish"}
 ]
 maintainers = [
   {name = "Patrick Kunzmann"}

--- a/python-src/fastpdb/__init__.py
+++ b/python-src/fastpdb/__init__.py
@@ -174,12 +174,12 @@ class PDBFile(BiotitePDBFile):
                 len_a, len_b, len_c,
                 np.deg2rad(alpha), np.deg2rad(beta), np.deg2rad(gamma)
             )
-        if isinstance(atoms, struc.AtomArray):
-            atoms.box = box
-        else:
-            atoms.box = np.repeat(
-                box[np.newaxis, ...], atoms.stack_depth(), axis=0
-            )
+            if isinstance(atoms, struc.AtomArray):
+                atoms.box = box
+            else:
+                atoms.box = np.repeat(
+                    box[np.newaxis, ...], atoms.stack_depth(), axis=0
+                )
         
 
         # Filter altloc IDs

--- a/tests/data/missing_CRYST1.pdb
+++ b/tests/data/missing_CRYST1.pdb
@@ -1,0 +1,17 @@
+REMARK 250 File created manually to test fastpdb parsing when the file is       
+REMARK 250 missing a CRYST1 record.                                             
+ATOM      1  N   ALA A   1      -0.525   1.362   0.000  1.00  0.00           N  
+ATOM      2  CA  ALA A   1       0.000   0.000   0.000  1.00  0.00           C  
+ATOM      3  C   ALA A   1       1.520   0.000   0.000  1.00  0.00           C  
+ATOM      4  O   ALA A   1       2.144  -0.812   0.681  1.00  0.00           O  
+ATOM      5  CB  ALA A   1      -0.507  -0.774  -1.206  1.00  0.00           C  
+ATOM      6  N   ALA A   2       2.116   0.911  -0.764  1.00  0.00           N  
+ATOM      7  CA  ALA A   2       3.571   1.003  -0.842  1.00  0.00           C  
+ATOM      8  C   ALA A   2       4.175   1.286   0.525  1.00  0.00           C  
+ATOM      9  O   ALA A   2       5.214   0.729   0.875  1.00  0.00           O  
+ATOM     10  CB  ALA A   2       3.992   2.091  -1.817  1.00  0.00           C  
+ATOM     11  N   ALA A   3       3.523   2.151   1.297  1.00  0.00           N  
+ATOM     12  CA  ALA A   3       4.010   2.498   2.628  1.00  0.00           C  
+ATOM     13  C   ALA A   3       4.089   1.269   3.519  1.00  0.00           C  
+ATOM     14  O   ALA A   3       5.035   1.116   4.289  1.00  0.00           O  
+ATOM     15  CB  ALA A   3       3.112   3.539   3.277  1.00  0.00           C  

--- a/tests/test_fastpdb.py
+++ b/tests/test_fastpdb.py
@@ -108,7 +108,7 @@ def test_get_structure(path, model, altloc, extra_fields, include_bonds):
     if ref_atoms.box is not None:
         assert np.allclose(test_atoms.box, ref_atoms.box)
     else:
-        assert test_atoms == None
+        assert test_atoms.box is None
     
     assert test_atoms.bonds == ref_atoms.bonds
     


### PR DESCRIPTION
This PR moves processing of `atoms.box` so that it only occurs if a box is successfully parsed from the input file. This allows PDB files which are missing CRYST1 records to be parsed correctly.

It also adds a new test file to verify this behaviour, and modifies the test body slightly to allow for files to contain atoms, but no box.

Closes https://github.com/biotite-dev/fastpdb/issues/7