### PR TITLE
Update pyo3 and numpy crate versions to support python 3.13

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -42,10 +42,10 @@ jobs:
         run: pip install .//dist//*.whl
       - name: Test wheel
         run: pytest --assert=plain tests
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: artifact-wheel-${{ matrix.os }}-${{ matrix.py-version }}
           path: .//dist//*.whl
-
 
   sdist:
     name: Build & test source distribution
@@ -66,8 +66,9 @@ jobs:
         run: pip install .//dist//*.tar.gz
       - name: Test source distribution
         run: pytest --assert=plain tests
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: artifact-tar-${{ matrix.os }}-${{ matrix.py-version }}
           path: dist//*.tar.gz
 
   benchmarks:
@@ -92,19 +93,20 @@ jobs:
     needs: [wheels, sdist, benchmarks]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: artifact
-        path: dist
-    - name: List distributions to be uploaded
-      run: ls dist
-    - name: Upload to GitHub Releases
-      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
-      if: github.event_name == 'release' && github.event.action == 'published'
-      with:
-        files: dist//*
-    - name: Upload to PyPI
-      uses: pypa/gh-action-pypi-publish@c7f29f7adef1a245bd91520e94867e5c6eedddcc
-      if: github.event_name == 'release' && github.event.action == 'published'
-      with:
-        password: ${{ secrets.PYPI_TOKEN }}
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: artifact-*
+          merge-multiple: true
+          path: dist
+      - name: List distributions to be uploaded
+        run: ls dist
+      - name: Upload to GitHub Releases
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        if: github.event_name == 'release' && github.event.action == 'published'
+        with:
+          files: dist//*
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@c7f29f7adef1a245bd91520e94867e5c6eedddcc
+        if: github.event_name == 'release' && github.event.action == 'published'
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -9,8 +9,10 @@ on:
   pull_request:
   release:
     types:
-    - published
+      - published
 
+env:
+  MATURIN_VERSION: "1.8"
 
 jobs:
   wheels:
@@ -32,10 +34,10 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
-            override: true
+          toolchain: stable
+          override: true
       - name: Install dependencies
-        run: pip install "maturin==1.4" "oldest-supported-numpy" pytest
+        run: pip install "maturin==$MATURIN_VERSION" "oldest-supported-numpy" pytest
       - name: Build wheel
         run: maturin build --release -i python -o dist
       - name: Install wheel
@@ -59,7 +61,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install dependencies
-        run: pip install "maturin==1.4" pytest
+        run: pip install "maturin==$MATURIN_VERSION" pytest
       - name: Build source distribution
         run: maturin sdist -o dist
       - name: Install source distribution

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         # Support both Mac x86_64 and arm64
-        os: [ubuntu-latest, windows-latest, macos-12, macos-latest]
-        py-version: ["3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        py-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install dependencies
         run: pip install "maturin==$MATURIN_VERSION" pytest
       - name: Build source distribution
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Install dependencies
         run: pip install .[test]
       - name: Run benchmarks
@@ -95,7 +95,8 @@ jobs:
     needs: [wheels, sdist, benchmarks]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
         with:
           pattern: artifact-*
           merge-multiple: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "fastpdb"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2018"
 
 [dependencies]
-numpy = "0.21"
+numpy = "0.24"
 ndarray = "0.16"
 
 [dependencies.pyo3]
-version = "0.21"
+version = "0.24"
 features = ["extension-module"]
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastpdb"
-version = "1.3.1"
+version = "1.3.2"
 description = "A high performance drop-in replacement for Biotite's PDBFile."
 readme = "README.rst"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,6 @@ python-source = "python-src"
 [build-system]
 requires = [
     "maturin >=1.0,<2.0",
-    "numpy == 1.26"
+    "numpy >=1.26,<1.27"
 ]
 build-backend = "maturin"

--- a/python-src/fastpdb/__init__.py
+++ b/python-src/fastpdb/__init__.py
@@ -1,7 +1,7 @@
 __name__ = "fastpdb"
 __author__ = "Patrick Kunzmann"
 __all__ = ["PDBFile"]
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 import os
 import warnings


### PR DESCRIPTION
Support for python 3.13 was added to PyO3 in version 0.22. The main purpose of this PR is to add this support to fastpdb.

Additionally I bumped the version of the numpy crate to pick up the latest changes. This is optional though, and if you think there are any problems with this I can remove the update.