### PR TITLE
Fix upload of release artifacts

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -92,7 +92,9 @@ jobs:
     name: Upload to GitHub Releases & PyPI
     permissions:
       contents: write
-    needs: [wheels, sdist, benchmarks]
+    needs:
+      - wheels
+      - sdist
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifacts


### PR DESCRIPTION
Currently the upload of release artifacts (sdist + wheels) requires the `benchmark` job to be succeeded, which itself does not run in release jobs. Hence, a new release would never upload artifacts. This PR fixes this problem.