### PR TITLE
pad short lines when reading from non-file io

### DIFF
--- a/python-src/fastpdb/__init__.py
+++ b/python-src/fastpdb/__init__.py
@@ -30,7 +30,7 @@ class PDBFile(BiotitePDBFile):
         else:
             if not is_text(file):
                 raise TypeError("A file opened in 'text' mode is required")
-            pdb_file._pdb_file = RustPDBFile(file.read().splitlines())
+            pdb_file._pdb_file = RustPDBFile([s.ljust(80) for s in file.read().splitlines()])
 
         # Synchronize with PDB file representation in Rust
         pdb_file.lines = pdb_file._pdb_file.lines

--- a/tests/test_fastpdb.py
+++ b/tests/test_fastpdb.py
@@ -195,3 +195,13 @@ def test_inferred_elements(tmp_path):
     atoms_guessed_elements = guessed_pdb_file.get_structure()
 
     assert atoms_guessed_elements.element.tolist() == atoms.element.tolist()
+
+
+def test_non_80_char_columns():
+    with open(DATA_PATH / "1l2y.pdb") as f:
+        lines = list(map(lambda s: s.rstrip(), f.readlines()))
+
+    pdb_file = fastpdb.PDBFile.read(StringIO(str.join("\n", lines)))
+    atoms = pdb_file.get_structure()
+
+    assert atoms is not None


### PR DESCRIPTION
Makes the behavior match between reading from `io.StringIO` and reading from a file.